### PR TITLE
fix(HPP-2079): complete implementation of 'q' (quality) parameter in SemanticMapper

### DIFF
--- a/source/image-handler/test/semantic-mapper/format.spec.ts
+++ b/source/image-handler/test/semantic-mapper/format.spec.ts
@@ -4,8 +4,8 @@
 import { ImageFormatTypes } from "../../lib";
 import { SemanticMapper } from "../../semantic-mapper";
 
-describe("format semantic", () => {
-  it("Should pass if the proper edit translations are applied and in the correct order", () => {
+describe.only("format semantic", () => {
+  it("format conversion jpg -> png", () => {
     // Arrange
     const event = {
       path: "/test-image-001.jpg",
@@ -22,6 +22,89 @@ describe("format semantic", () => {
     // Assert
     const expectedResult = {
       edits: { resize: { fit: "inside", height: null, width: null }, toFormat: "png" },
+    };
+    expect(edits).toEqual(expectedResult.edits);
+  });
+
+  it("Should map format and quality when it is a valid format", () => {
+    // Arrange
+    const event = {
+      path: "/test-image-001.png",
+      queryStringParameters: {
+        signature: "dummySig",
+        q: "90",
+      },
+    };
+
+    // Act
+    const customMapper = new SemanticMapper();
+    const edits = customMapper.mapPathToEdits(event);
+
+    // Assert
+    expect(edits.png).toEqual({ quality: 90 });
+  });
+
+  it("Should map format and default quality when conversion to jpeg and q is NOT set", () => {
+    // Arrange
+    const event = {
+      path: "/test-image-001.png",
+      queryStringParameters: {
+        signature: "dummySig",
+        fm: ImageFormatTypes.JPEG,
+      },
+    };
+
+    // Act
+    const customMapper = new SemanticMapper();
+    const edits = customMapper.mapPathToEdits(event);
+
+    // Assert
+    const expectedResult = {
+      edits: { resize: { fit: "inside", height: null, width: null }, toFormat: "jpeg", jpeg: { quality: 60 } },
+    };
+    expect(edits).toEqual(expectedResult.edits);
+  });
+
+  it("Should map format and default quality when conversion to jpeg and q IS set", () => {
+    // Arrange
+    const event = {
+      path: "/test-image-001.png",
+      queryStringParameters: {
+        signature: "dummySig",
+        fm: ImageFormatTypes.JPEG,
+        q: "90",
+      },
+    };
+
+    // Act
+    const customMapper = new SemanticMapper();
+    const edits = customMapper.mapPathToEdits(event);
+
+    // Assert
+    const expectedResult = {
+      edits: { resize: { fit: "inside", height: null, width: null }, toFormat: "jpeg", jpeg: { quality: 90 } },
+    };
+    expect(edits).toEqual(expectedResult.edits);
+  });
+
+  it("Should not map format and quality with any other format", () => {
+    // Arrange
+    const event = {
+      path: "/test-image-001.png",
+      queryStringParameters: {
+        signature: "dummySig",
+        fm: ImageFormatTypes.WEBP,
+        q: "90",
+      },
+    };
+
+    // Act
+    const customMapper = new SemanticMapper();
+    const edits = customMapper.mapPathToEdits(event);
+
+    // Assert
+    const expectedResult = {
+      edits: { resize: { fit: "inside", height: null, width: null }, toFormat: "webp", webp: { quality: 90 } },
     };
     expect(edits).toEqual(expectedResult.edits);
   });


### PR DESCRIPTION
New deployment results:

```
 ✅  ServerlessImageHandlerStack

✨  Deployment time: 288.82s

Outputs:
ServerlessImageHandlerStack.ApiEndpoint = https://diuov886awaop.cloudfront.net
ServerlessImageHandlerStack.CorsEnabled = No
ServerlessImageHandlerStack.DemoUrl = https://dq0pjjfo5okj.cloudfront.net/index.html
ServerlessImageHandlerStack.LogRetentionPeriod = 1
ServerlessImageHandlerStack.SourceBuckets = labster-sandbox-portal-cms
ServerlessImageHandlerStack.UseSemanticUrl = Yes
Stack ARN:
arn:aws:cloudformation:us-east-1:071243229994:stack/ServerlessImageHandlerStack/b2f23fd0-dacf-11ee-9af7-0af95e0a0a43

✨  Total time: 295.3s
```



**Description of changes:**

`q` parameter is fully honoured.


**Checklist**
- [x] :wave: I have added unit tests for all code changes.
- [x] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
