### PR TITLE
fix(HPP-2201): refactor format semantic mapper and fix support for SVG images

### DIFF
--- a/source/image-handler/image-request.ts
+++ b/source/image-handler/image-request.ts
@@ -245,20 +245,20 @@ export class ImageRequest {
    * @returns The edits to be made to the original image.
    */
   public parseImageEdits(event: ImageHandlerEvent, requestType: RequestTypes): ImageEdits {
-    const thumborMapping = new ThumborMapper();
-    const semanticMapping = new SemanticMapper();
-
     switch (requestType) {
       case RequestTypes.DEFAULT:
         const decoded = this.decodeRequest(event);
         return decoded.edits;
       case RequestTypes.THUMBOR:
+        const thumborMapping = new ThumborMapper();
         return thumborMapping.mapPathToEdits(event.path);
       case RequestTypes.SEMANTIC:
+        const semanticMapping = new SemanticMapper();
         return semanticMapping.mapPathToEdits(event);
       case RequestTypes.CUSTOM:
-        const parsedPath = thumborMapping.parseCustomPath(event.path);
-        return thumborMapping.mapPathToEdits(parsedPath);
+        const customMapping = new ThumborMapper();
+        const parsedPath = customMapping.parseCustomPath(event.path);
+        return customMapping.mapPathToEdits(parsedPath);
       default:
         throw new ImageHandlerError(
           StatusCodes.BAD_REQUEST,

--- a/source/image-handler/semantic-mapper.ts
+++ b/source/image-handler/semantic-mapper.ts
@@ -56,8 +56,8 @@ export class SemanticMapper {
     if (width === null || height === null) {
       resizeEdit.resize.fit = ImageFitTypes.INSIDE;
     }
-    resizeEdit.resize.width = width;
-    resizeEdit.resize.height = height;
+    resizeEdit.resize.width = width === 0 ? null : width;
+    resizeEdit.resize.height = height === 0 ? null : height;
 
     return resizeEdit;
   }

--- a/source/image-handler/semantic-mapper.ts
+++ b/source/image-handler/semantic-mapper.ts
@@ -5,7 +5,8 @@
 import { ImageEdits, ImageFitTypes, ImageFormatTypes, ImageHandlerEvent } from "./lib";
 
 export class SemanticMapper {
-  private  readonly EMPTY_IMAGE_EDITS: ImageEdits = {};
+  private readonly EMPTY_IMAGE_EDITS: ImageEdits = {};
+  private originalFormat: string;
 
   /**
    * Initializer function for creating a new Custom mapping, used by the image
@@ -14,13 +15,15 @@ export class SemanticMapper {
    * @returns Image edits based on the request path.
    */
   public mapPathToEdits(event: ImageHandlerEvent): ImageEdits {
+    this.originalFormat = event.path.substring(event.path.lastIndexOf(".") + 1);
 
-    if ([event.multiValueQueryStringParameters?.h,
-    event.multiValueQueryStringParameters?.w,
-    event.multiValueQueryStringParameters?.fit,
-    event.multiValueQueryStringParameters?.fm,
-    event.multiValueQueryStringParameters?.q]
-      .some((p) => { p?.length > 1; })) {
+    if (this.originalFormat.toLocaleLowerCase() === "svg") {
+      return this.EMPTY_IMAGE_EDITS;
+    }
+
+    const { h, w, fit, fm, q } = event.multiValueQueryStringParameters || {};
+
+    if ([h, w, fit, fm, q].some(p => p?.length > 1)) {
       throw new Error("Multiple values for the same parameter are not allowed.");
     }
 
@@ -46,6 +49,10 @@ export class SemanticMapper {
       const intDim = parseInt(dim as string);
       return isNaN(intDim) ? 0 : intDim;
     });
+
+    if (width === 0 && height === 0) {
+      return this.EMPTY_IMAGE_EDITS;
+    }
 
     const resizeEdit: ImageEdits = { resize: {} };
 
@@ -116,17 +123,17 @@ export class SemanticMapper {
    */
   private mapFormat(event: ImageHandlerEvent): ImageEdits {
     const { fm: targetFormat, q: qualityParam } = event.queryStringParameters || {};
-    const originalFormat = event.path.substring(event.path.lastIndexOf(".") + 1) as ImageFormatTypes;
+    const originalFormat = this.originalFormat as ImageFormatTypes;
     const format = targetFormat || originalFormat;
     const isJpeg = ['jpg', 'jpeg'].includes(targetFormat);
     const quality = parseInt(qualityParam as string, 10);
-  
+
     const edits: ImageEdits = {
       ...(targetFormat && { toFormat: targetFormat }),
       ...(qualityParam && !isNaN(quality) && { [format]: { quality } }),
       ...(isJpeg && !qualityParam && { jpeg: { quality: 60 } }),
     };
-  
+
     return edits;
   }
 }

--- a/source/image-handler/test/semantic-mapper/format.spec.ts
+++ b/source/image-handler/test/semantic-mapper/format.spec.ts
@@ -4,7 +4,7 @@
 import { ImageFormatTypes } from "../../lib";
 import { SemanticMapper } from "../../semantic-mapper";
 
-describe.only("format semantic", () => {
+describe("format semantic", () => {
   it("format conversion jpg -> png", () => {
     // Arrange
     const event = {
@@ -21,7 +21,7 @@ describe.only("format semantic", () => {
 
     // Assert
     const expectedResult = {
-      edits: { resize: { fit: "inside", height: null, width: null }, toFormat: "png" },
+      edits: { toFormat: "png" },
     };
     expect(edits).toEqual(expectedResult.edits);
   });
@@ -60,7 +60,7 @@ describe.only("format semantic", () => {
 
     // Assert
     const expectedResult = {
-      edits: { resize: { fit: "inside", height: null, width: null }, toFormat: "jpeg", jpeg: { quality: 60 } },
+      edits: {  toFormat: "jpeg", jpeg: { quality: 60 } },
     };
     expect(edits).toEqual(expectedResult.edits);
   });
@@ -82,7 +82,7 @@ describe.only("format semantic", () => {
 
     // Assert
     const expectedResult = {
-      edits: { resize: { fit: "inside", height: null, width: null }, toFormat: "jpeg", jpeg: { quality: 90 } },
+      edits: {  toFormat: "jpeg", jpeg: { quality: 90 } },
     };
     expect(edits).toEqual(expectedResult.edits);
   });
@@ -104,7 +104,7 @@ describe.only("format semantic", () => {
 
     // Assert
     const expectedResult = {
-      edits: { resize: { fit: "inside", height: null, width: null }, toFormat: "webp", webp: { quality: 90 } },
+      edits: {  toFormat: "webp", webp: { quality: 90 } },
     };
     expect(edits).toEqual(expectedResult.edits);
   });

--- a/source/image-handler/test/semantic-mapper/resize.spec.ts
+++ b/source/image-handler/test/semantic-mapper/resize.spec.ts
@@ -4,10 +4,10 @@
 import { SemanticMapper } from "../../semantic-mapper";
 
 describe("resize", () => {
-  it("Should pass if the proper edit translations are applied and in the correct order", () => {
+  it("Should pass if the proper edit translations are applied and in the correct order, w, h", () => {
     // Arrange
     const event = {
-      path:"/test-image-001.jpg",
+      path: "/test-image-001.jpg",
       queryStringParameters: {
         signature: "dummySig",
         w: 400,
@@ -26,10 +26,10 @@ describe("resize", () => {
     expect(edits).toEqual(expectedResult.edits);
   });
 
-  it("Should pass if the proper edit translations are applied and in the correct order", () => {
+  it("Should pass if the proper edit translations are applied and in the correct order, h", () => {
     // Arrange
     const event = {
-      path:"/test-image-001.jpg",
+      path: "/test-image-001.jpg",
       queryStringParameters: {
         signature: "dummySig",
         h: 300,
@@ -47,10 +47,10 @@ describe("resize", () => {
     expect(edits).toEqual(expectedResult.edits);
   });
 
-  it("Should pass if the proper edit translations are applied and in the correct order", () => {
+  it("Should pass if the proper edit translations are applied and in the correct order, w", () => {
     // Arrange
     const event = {
-      path:"/test-image-001.jpg",
+      path: "/test-image-001.jpg",
       queryStringParameters: {
         signature: "dummySig",
         w: 400,
@@ -68,10 +68,10 @@ describe("resize", () => {
     expect(edits).toEqual(expectedResult.edits);
   });
 
-  it("Should pass if the proper edit translations are applied and in the correct order", () => {
+  it("Should pass if the proper edit translations are applied and in the correct order, !w !h", () => {
     // Arrange
     const event = {
-      path:"/test-image-001.jpg",
+      path: "/test-image-001.jpg",
       queryStringParameters: {
         signature: "dummySig",
         w: 0,
@@ -85,7 +85,7 @@ describe("resize", () => {
 
     // Assert
     const expectedResult = {
-      edits: { resize: { width: null, height: null, fit: "inside" } },
+      edits: {},
     };
     expect(edits).toEqual(expectedResult.edits);
   });
@@ -93,7 +93,7 @@ describe("resize", () => {
   it("Tests error on deployment, no parameters produces these edits", () => {
     // Arrange
     const event = {
-      path:"/test-image-001.jpg",
+      path: "/test-image-001.jpg",
     }
 
     // Act
@@ -102,7 +102,7 @@ describe("resize", () => {
 
     // Assert
     const expectedResult = {
-      edits: { resize: { width: null, height: null, fit: "inside" } },
+      edits: {},
     };
     expect(edits).toEqual(expectedResult.edits);
   });


### PR DESCRIPTION
**Issue #, if available:**
<!-- If there're any related issues, please add the issue number here. -->

Deployment output:

```
ServerlessImageHandlerStack.ApiEndpoint = https://d2lxnqlnyu0xfq.cloudfront.net
ServerlessImageHandlerStack.CorsEnabled = No
ServerlessImageHandlerStack.DemoUrl = https://d24t9nxjsydavq.cloudfront.net/index.html
ServerlessImageHandlerStack.LogRetentionPeriod = 1
ServerlessImageHandlerStack.SourceBuckets = labster-sandbox-portal-cms
ServerlessImageHandlerStack.UseSemanticUrl = Yes
Stack ARN:
arn:aws:cloudformation:us-east-1:071243229994:stack/ServerlessImageHandlerStack/2f3f56e0-eae3-11ee-84b9-0e17935cafe9

```

SVG files skip every edition.

https://d2lxnqlnyu0xfq.cloudfront.net/1.jpg
https://d2lxnqlnyu0xfq.cloudfront.net/2.png
https://d2lxnqlnyu0xfq.cloudfront.net/4.svg

**Description of changes:**
<!-- Please describe the changes you made -->


**Checklist**
- [x] :wave: I have added unit tests for all code changes.
- [ ] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
